### PR TITLE
Add podspec file

### DIFF
--- a/CleanroomLogger.podspec
+++ b/CleanroomLogger.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = 'CleanroomLogger'
+  s.version      = '7.0.0'
+  s.summary      = 'Extensible Swift-based logging API that is simple, lightweight and performant'
+  s.homepage     = 'https://github.com/emaloney/CleanroomLogger'
+  s.author       = 'emaloney'
+  s.source       = { :git => 'https://github.com/emaloney/CleanroomLogger.git', :tag => s.version }
+  s.platform     = :ios, '10.2'
+  s.source_files = 'Sources/*'
+  s.license = 'MIT'
+end

--- a/CleanroomLogger.podspec
+++ b/CleanroomLogger.podspec
@@ -6,6 +6,6 @@ Pod::Spec.new do |s|
   s.author       = 'emaloney'
   s.source       = { :git => 'https://github.com/emaloney/CleanroomLogger.git', :tag => s.version }
   s.platform     = :ios, '10.2'
-  s.source_files = 'Sources/*'
+  s.source_files = 'Sources/*.swift'
   s.license = 'MIT'
 end


### PR DESCRIPTION
Effort is to update point_of_sale to swift 5, so we're cleaning up and moving from andrew's personal github to here. Fork is to add a podspec file.

Update from andrew's fork: changed the `platform` from 9.0 to 10.2 in agreement with 
https://github.com/upserve/CleanroomLogger/compare/master...swift-5?expand=1
